### PR TITLE
fix: disable standalone mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,5 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+.idea

--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,5 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
-  output: 'standalone',
   experimental: {
     // 'appDir' entfernen, da es nicht mehr benötigt wird
   }


### PR DESCRIPTION
Remove Next.js standalone mode, so startup defined in ecosystem.config.js works on Azure

Also configured startup command on Azure Web App:
`pm2 start /home/site/wwwroot/ecosystem.config.js --no-daemon`